### PR TITLE
Fix typo in variable name + reference to webkit API

### DIFF
--- a/technosweb/js/tts.js
+++ b/technosweb/js/tts.js
@@ -1,11 +1,17 @@
 'use strict';
 
-const theSpeechRecognition = window.SpeechRecognition || webkitSpeechRecognition;
-const recognition = new theSpeechRecognition();
-
+const theSpeechRecognition = window.SpeechRecognition || window.webkitSpeechRecognition;
+let recognition = null;
+if (!!theSpeechRecognition) {
+    recognition = new theSpeechRecognition();
+} else {
+    console.log("No Speech Recognition API available");
+}
 const initTTS = function() {
     let subtitle = ['div.transcript'].toDOM(document.querySelector('body')); 
     subtitle.setAttribute('style', 'visibility: hidden;');
+    if (! recognition)
+       return;
     recognition.lang = 'FR_fr';
     recognition.continuous = true;
     recognition.interimResults = true;


### PR DESCRIPTION
Il y avait une typo dans le nom de  variable (+ une réf directe à webkitSpeech... qui  plantait pour tout le monde). C'est réparé.